### PR TITLE
Reorganized dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: celohq/node10-gcloud:v3
+    - image: us.gcr.io/celo-testnet/circleci-node12:1.0.0
   working_directory: ~/bls12377js
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: celohq/node8:gcloud
+    - image: celohq/node10-gcloud:v3
   working_directory: ~/bls12377js
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^12.11.7",
     "big-integer": "^1.6.44",
-    "@stablelib/blake2xs": "0.10.4",
+    "@stablelib/blake2xs": "0.10.4"
+  },
+  "devDependencies": {
+    "@types/chai": "^4.1.7",
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^12.11.7",
     "chai": "^4.2.0",
     "mocha": "^6.2.2",
     "ts-node": "^8.4.1",
     "typescript": "^3.6.4"
-  },
-  "devDependencies": {
-    "@types/chai": "^4.1.7",
-    "@types/mocha": "^5.2.7"
   }
 }


### PR DESCRIPTION
## Motivation

I checked why the total size of a lambda was so big and among other things I found that there's typescript as a dependency:
```
$ yarn why typescript
yarn why v1.22.4
[1/4] 🤔  Why do we have the module "typescript"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "typescript@3.9.7"
info Has been hoisted to "typescript"
info Reasons this module exists
   - Specified in "devDependencies"
   - Hoisted from "@celo#utils#bls12377js#typescript"
info Disk size without dependencies: "52.33MB"
info Disk size with unique dependencies: "52.33MB"
info Disk size with transitive dependencies: "52.33MB"
info Number of shared dependencies: 0
✨  Done in 0.75s.
```

The library itself is used here https://github.com/celo-org/celo-monorepo/blob/master/packages/sdk/utils/package.json#L34
This PR moves some of the dependencies to dev dependencies to minimize the total size of the production build.