### PR TITLE
upgrade to typescript 4 

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,11 +1,7 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];

--- a/dist/src/f.js
+++ b/dist/src/f.js
@@ -108,7 +108,7 @@ var F = /** @class */ (function () {
         return F.fromBig(bigInt(this.num));
     };
     F.prototype.toString = function (base) {
-        return "F(".concat(this.num.toString(base), ")");
+        return "F(" + this.num.toString(base) + ")";
     };
     return F;
 }());

--- a/dist/src/f2.js
+++ b/dist/src/f2.js
@@ -96,7 +96,7 @@ var F2 = /** @class */ (function () {
         return [this.c0.clone(), this.c1.clone()];
     };
     F2.prototype.toString = function (base) {
-        return "F2(".concat(this.c0.toString(base), ", ").concat(this.c1.toString(base), ")");
+        return "F2(" + this.c0.toString(base) + ", " + this.c1.toString(base) + ")";
     };
     return F2;
 }());

--- a/dist/src/group.js
+++ b/dist/src/group.js
@@ -122,7 +122,7 @@ var Group = /** @class */ (function () {
         return p;
     };
     Group.prototype.toString = function (base) {
-        return "G(".concat(this.x().toString(base), ", ").concat(this.y().toString(base), ", ").concat(this.z().toString(base), ")");
+        return "G(" + this.x().toString(base) + ", " + this.y().toString(base) + ", " + this.z().toString(base) + ")";
     };
     return Group;
 }());

--- a/dist/test/bls.js
+++ b/dist/test/bls.js
@@ -1,11 +1,7 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -75,8 +71,8 @@ describe('bls', function () {
                 (0, chai_1.expect)(popHex).to.equal(line[2]);
             }
             catch (e) {
-                console.log("error: ".concat(e));
-                console.log("problematic line: ".concat(line));
+                console.log("error: " + e);
+                console.log("problematic line: " + line);
                 throw e;
             }
         }
@@ -95,8 +91,8 @@ describe('bls', function () {
                 (0, chai_1.expect)(popHex).to.equal(line[2]);
             }
             catch (e) {
-                console.log("error: ".concat(e));
-                console.log("problematic line: ".concat(line));
+                console.log("error: " + e);
+                console.log("problematic line: " + line);
                 throw e;
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "chai": "^4.2.0",
         "mocha": "^9.2.2",
         "ts-node": "^8.4.1",
-        "typescript": "^3.6.4"
+        "typescript": "^4.4.2"
       }
     },
     "node_modules/@stablelib/binary": {
@@ -1968,9 +1968,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "chai": "^4.2.0",
     "mocha": "^9.2.2",
     "ts-node": "^8.4.1",
-    "typescript": "^3.6.4"
+    "typescript": "^4.4.3"
   }
 }


### PR DESCRIPTION
Using version 3 was causing issues on monorepo e2e tests. 


seems the main differences is that strings are not contacted with this compiler. 